### PR TITLE
Optimize ddoc cache opener

### DIFF
--- a/include/ddoc_cache.hrl
+++ b/include/ddoc_cache.hrl
@@ -1,0 +1,22 @@
+% Copyright 2015 Cloudant
+%
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+%% types
+-type db_name() :: iodata().
+-type doc_id() :: iodata().
+-type doc_hash() :: <<_:128>>.
+-type revision() :: {pos_integer(), doc_hash()}.
+-type doc_key() :: {db_name(), doc_id()}
+    | {db_name(), atom()}
+    | {db_name(), doc_id(), revision()}.

--- a/include/ddoc_cache.hrl
+++ b/include/ddoc_cache.hrl
@@ -18,5 +18,13 @@
 -type doc_hash() :: <<_:128>>.
 -type revision() :: {pos_integer(), doc_hash()}.
 -type doc_key() :: {db_name(), doc_id()}
-    | {db_name(), atom()}
+    | {db_name(), 'custom', atom()}
     | {db_name(), doc_id(), revision()}.
+
+% cache record
+-define(CACHE, ddoc_cache_lru).
+-record(entry, {
+    key :: doc_key() | tuple(),
+    val :: binary() | '_',
+    ts :: pos_integer() | atom() | '_'
+}).

--- a/src/ddoc_cache.app.src
+++ b/src/ddoc_cache.app.src
@@ -19,9 +19,5 @@
         twig
     ]},
     {mod, {ddoc_cache_app, []}},
-    {env, [
-        {max_objects, unlimited},
-        {max_size, 104857600}, % 100M
-        {max_lifetime, 60000} % 1m
-    ]}
+    {env, []}
 ]}.

--- a/src/ddoc_cache.erl
+++ b/src/ddoc_cache.erl
@@ -52,7 +52,7 @@ open_doc(DbName, DocId, RevId) ->
     end.
 
 open_validation_funs(DbName) ->
-    Key = {DbName, validation_funs},
+    Key = {DbName, custom, validation_funs},
     case ddoc_cache_opener:lookup(Key) of
         {ok, _} = Resp ->
             couch_stats:increment_counter([ddoc_cache, hit]),
@@ -66,7 +66,7 @@ open_validation_funs(DbName) ->
     end.
 
 open_custom(DbName, Mod) ->
-    Key = {DbName, Mod},
+    Key = {DbName, custom, Mod},
     case ddoc_cache_opener:lookup(Key) of
         {ok, _} = Resp ->
             couch_stats:increment_counter([ddoc_cache, hit]),

--- a/src/ddoc_cache.erl
+++ b/src/ddoc_cache.erl
@@ -24,17 +24,12 @@ stop() ->
     application:stop(ddoc_cache).
 
 open_doc(DbName, DocId) ->
-    Key = {DbName, DocId, '_'},
-    case ddoc_cache_opener:match_newest(Key) of
-        {ok, _} = Resp ->
-            couch_stats:increment_counter([ddoc_cache, hit]),
-            Resp;
-        missing ->
-            couch_stats:increment_counter([ddoc_cache, miss]),
-            ddoc_cache_opener:open_doc(DbName, DocId);
-        recover ->
-            couch_stats:increment_counter([ddoc_cache, recovery]),
-            ddoc_cache_opener:recover_doc(DbName, DocId)
+    case ddoc_cache_fetcher_sup:get_revision({DbName, DocId}) of
+    {ok, RevId} ->
+        ddoc_cache:open_doc(DbName, DocId, RevId);
+    not_found ->
+        couch_stats:increment_counter([ddoc_cache, miss]),
+        ddoc_cache_opener:open_doc(DbName, DocId)
     end.
 
 open_doc(DbName, DocId, RevId) ->

--- a/src/ddoc_cache_fetcher.erl
+++ b/src/ddoc_cache_fetcher.erl
@@ -3,120 +3,90 @@
 -module(ddoc_cache_fetcher).
 
 -behaviour(gen_server).
+-vsn(1).
 
--export([start_link/1, open/1, open/2, recover/2, recover_info/2, refresh/1]).
+-export([start_link/1, start/1, open/1, open/2]).
 
 %% gen_server.
 -export([init/1, handle_call/3, handle_cast/2,
     handle_info/2, terminate/2, code_change/3]).
 
+-include("ddoc_cache.hrl").
 -include_lib("couch/include/couch_db.hrl").
--include_lib("mem3/include/mem3.hrl").
 
 -define(CACHE, ddoc_cache_lru).
--define(REFRESH, 60000).
--record(state, {key, rev, handler = recover, pid, tref, queue = []}).
+-record(state, {key, pid, doc, rev, queue = []}).
 
--type db_name() :: iodata().
--type doc_id() :: iodata().
--type doc_hash() :: <<_:128>>.
--type revision() :: {pos_integer(), doc_hash()}.
--type doc_key() :: {db_name(), doc_id()} | {db_name(), atom()}
-    | {db_name(), doc_id(), revision()}.
 
 -spec start_link(doc_key()) -> {ok, pid()} | {error, term()}.
 start_link(Args) ->
-	gen_server:start_link(?MODULE, Args, []).
+    gen_server:start_link(?MODULE, Args, []).
 
--spec open(pid()) -> {ok, #doc{}}.
-open(Pid) ->
-    gen_server:call(Pid, open).
+%% @doc - Starts fetcher with a given key under supervision tree
+-spec start(doc_key()) -> {ok, pid()} | {ok, 'ignore'} | {error, term()}.
+start(Key) ->
+    ChildSpec = {{fetcher, Key}, ?MODULE, [Key]},
+    ddoc_cache_fetcher_sup:start_child(ChildSpec).
 
--spec open(pid(), term()) -> {ok, #doc{}}.
-open(Pid, To) ->
-    gen_server:call(Pid, {open, To}).
+-spec open(doc_key()) -> {ok, #doc{}} | {error, term()}.
+open(Key) ->
+    {ok, Pid} = start(Key),
+    case erlang:is_process_alive(Pid) of
+    true ->
+        gen_server:call(Pid, open);
+    false ->
+        ddoc_cache_opener:lookup(Key)
+    end.
 
--spec refresh(pid()) -> ok.
-refresh(Pid) ->
-    gen_server:cast(Pid, refresh).
-
--spec recover(pid(), doc_key()) -> {ok, #doc{}} | {error, term()}.
-recover(Pid, Key) ->
-    gen_server:cast(Pid, {recover, recover(Key)}).
-
--spec recover_info(pid(), doc_key()) -> {ok, #doc_info{}} | {error, term()}.
-recover_info(Pid, Key) ->
-    gen_server:cast(Pid, {recover_info, recover_info(Key)}).
+-spec open(doc_key(), term()) -> {ok, #doc{}}.
+open(Key, To) ->
+    {ok, Pid} = start(Key),
+    case erlang:is_process_alive(Pid) of
+    true ->
+        gen_server:cast(Pid, {open, To});
+    false ->
+        Reply = ddoc_cache_opener:lookup(Key),
+        gen_server:reply(To, Reply)
+    end.
 
 
 init(Key) ->
     process_flag(trap_exit, true),
     {ok, #state{key = Key}, 0}.
 
-handle_call(open, From, #state{queue = Q, tref = undefined} = State) ->
+handle_call(open, From, #state{queue = Q} = State) ->
     {noreply, State#state{queue = [From|Q]}};
-handle_call(open, From, #state{queue = Q, tref = TRef} = State) ->
-    {ok, cancel} = timer:cancel(TRef),
-    {noreply, State#state{queue=[From|Q], tref=undefined, handler=recover}, 0};
-handle_call({open, To}, _From, #state{queue = Q} = State) ->
-    {noreply, State#state{queue = [To|Q]}}.
+handle_call(Msg, _, State) ->
+    {stop, {invalid_call, Msg}, {invalid_call, Msg}, State}.
 
-handle_cast(refresh, #state{tref = undefined} = State) ->
-    {noreply, State};
-handle_cast(refresh, #state{key = {DbName, DocId}, rev = Rev} = State) ->
-    {ok, cancel} = timer:cancel(State#state.tref),
-    case ets_lru:member(?CACHE, {DbName, DocId, Rev}) of
-    true ->
-        {noreply, State#state{tref = undefined, handler = recover_info}, 0};
-    false ->
-        {stop, normal, State#state{tref = undefined}}
-    end;
-handle_cast({recover_info, {ok, #doc_info{revs = RecRevs}}}, State) ->
-    Revs = [R || #rev_info{rev=R, deleted=D} <- RecRevs, D /= true],
-    [NewRev|_] = lists:sort(fun({A,_}, {B,_}) -> A > B end, Revs),
-    case NewRev =:= State#state.rev of
-    true ->
-        {noreply, State};
-    false ->
-        {noreply, State#state{pid=undefined, handler=recover}, 0}
-    end;
-handle_cast({recover_info, Reply}, #state{key = Key} = State) ->
-    twig:log(notice, "can't get doc info for ~p : ~w", [Key, Reply]),
-    {noreply, State};
-handle_cast({recover, {ok, Doc}}, #state{key = Key, queue = Q} = State) ->
-    case Key of
-    {_, DocId} when not is_atom(DocId) ->
-        {RevDepth, [RevHash| _]} = Doc#doc.revs,
-        Rev = {RevDepth, RevHash},
-        ok = store_ddoc(Key, Doc, Rev),
-        [gen_server:reply(From, {ok, Doc}) || From <- Q],
-        {noreply, State#state{queue = [], rev = Rev}};
-    _ ->
-        ok = store_ddoc(Key, Doc),
-        [gen_server:reply(From, {ok, Doc}) || From <- Q],
-        {noreply, State#state{queue = []}}
-    end;
-handle_cast({recover, Reply}, #state{queue = Q} = State) ->
+handle_cast({open, To}, #state{queue = Q} = State) ->
+    {noreply, State#state{queue = [To|Q]}};
+handle_cast({recover, {ok, Doc}}, #state{key = Key} = State) ->
+    ok = store_ddoc(Key, Doc),
+    maybe_start_synchronizer(Key, Doc),
+    {noreply, State#state{doc = {ok, Doc}}};
+handle_cast({recover, Reply}, State) ->
+    {noreply, State#state{doc = Reply}};
+handle_cast(reply, #state{doc = Reply, queue = Q} = State) ->
     [gen_server:reply(From, Reply) || From <- Q],
-    {noreply, State#state{queue = []}}.
+    {stop, normal, State#state{queue = []}};
+handle_cast(Msg, State) ->
+    {stop, {invalid_cast, Msg}, State}.
 
-handle_info(timeout, #state{key = Key, handler = Handler} = State) ->
+handle_info(timeout, #state{key = Key} = State) ->
+    maybe_stop_synchronizer(Key),
     Self = self(),
     Pid = proc_lib:spawn_link(fun() ->
-        erlang:apply(?MODULE, Handler, [Self, Key])
+        erlang:apply(fun recover/2, [Self, Key])
     end),
     {noreply, State#state{pid = Pid}};
-handle_info({'EXIT', Pid, normal}, #state{pid=Pid, rev=undefined} = State) ->
-    {stop, normal, State#state{pid = undefined}};
 handle_info({'EXIT', Pid, normal}, #state{pid=Pid} = State) ->
-    {ok, TRef} = timer:send_after(?REFRESH, self(), {'$gen_cast', refresh}),
-    {noreply, State#state{pid = undefined, tref = TRef}, hibernate};
-handle_info({'EXIT', Pid, Err}, #state{pid=Pid} = State) ->
-    {stop, {error, Err}, State#state{pid = undefined}};
-handle_info({'EXIT', _, _Reason}, State) ->
-    {noreply, State};
+    gen_server:cast(self(), reply),
+    {noreply, State#state{pid = undefined}};
+handle_info({'EXIT', Pid, Reason}, #state{pid=Pid} = State) ->
+    {stop, Reason, State#state{pid = undefined}};
 handle_info(Msg, State) ->
-    {stop, {unknown_msg, Msg}, State}.
+    {stop, {invalid_info, Msg}, State}.
 
 terminate(Reason, #state{pid = Pid}) ->
     case is_pid(Pid) andalso erlang:is_process_alive(Pid) of
@@ -129,21 +99,37 @@ code_change(_OldVsn, State, _Extra) ->
 
 %% priv
 
-recover({DbName, validation_funs}) ->
+recover(Pid, Key) ->
+    gen_server:cast(Pid, {recover, recover(Key)}).
+
+recover({DbName, custom, validation_funs}) ->
     ddoc_cache_opener:recover_validation_funs(DbName);
-recover({DbName, Mod}) when is_atom(Mod) ->
+recover({DbName, custom, Mod}) when is_atom(Mod) ->
     Mod:recover(DbName);
 recover({DbName, DocId}) ->
     ddoc_cache_opener:recover_doc(DbName, DocId);
 recover({DbName, DocId, Rev}) ->
     ddoc_cache_opener:recover_doc(DbName, DocId, Rev).
 
-recover_info({DbName, DocId}) ->
-    ddoc_cache_opener:recover_doc_info(DbName, DocId).
-
 store_ddoc(Key, Doc) ->
     ok = ets_lru:insert(?CACHE, Key, Doc).
 
-store_ddoc({DbName, DocId} = Key, Doc, Rev) ->
-    ok = ets_lru:insert(?CACHE, {DbName, DocId, Rev}, Doc),
-    ok = ddoc_cache_fetcher_sup:set_revision(Key, Rev).
+maybe_start_synchronizer({DbName, DocId}, Doc) when not is_atom(DocId) ->
+    {RevDepth, [RevHash| _]} = Doc#doc.revs,
+    Rev = {RevDepth, RevHash},
+    ok = store_ddoc({DbName, DocId, Rev}, Doc),
+    {ok, _} = ddoc_cache_synchronizer:start({DbName, DocId}, Rev);
+maybe_start_synchronizer({_, custom, _}, _) ->
+    ok;
+maybe_start_synchronizer({DbName, DocId, Rev}, Doc) ->
+    case ddoc_cache_opener:member({DbName, DocId}) of
+    true -> ok;
+    false ->
+        ok = ddoc_cache_opener:store_doc({DbName, DocId}, Doc),
+        {ok, _} = ddoc_cache_synchronizer:start({DbName, DocId}, Rev)
+    end.
+
+maybe_stop_synchronizer({DbName, DocId}) ->
+    ddoc_cache_synchronizer:stop({DbName, DocId});
+maybe_stop_synchronizer(_) ->
+    ok.

--- a/src/ddoc_cache_fetcher.erl
+++ b/src/ddoc_cache_fetcher.erl
@@ -1,0 +1,149 @@
+% Copyright 2014 Cloudant. All rights reserved.
+
+-module(ddoc_cache_fetcher).
+
+-behaviour(gen_server).
+
+-export([start_link/1, open/1, open/2, recover/2, recover_info/2, refresh/1]).
+
+%% gen_server.
+-export([init/1, handle_call/3, handle_cast/2,
+    handle_info/2, terminate/2, code_change/3]).
+
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("mem3/include/mem3.hrl").
+
+-define(CACHE, ddoc_cache_lru).
+-define(REFRESH, 60000).
+-record(state, {key, rev, handler = recover, pid, tref, queue = []}).
+
+-type db_name() :: iodata().
+-type doc_id() :: iodata().
+-type doc_hash() :: <<_:128>>.
+-type revision() :: {pos_integer(), doc_hash()}.
+-type doc_key() :: {db_name(), doc_id()} | {db_name(), atom()}
+    | {db_name(), doc_id(), revision()}.
+
+-spec start_link(doc_key()) -> {ok, pid()} | {error, term()}.
+start_link(Args) ->
+	gen_server:start_link(?MODULE, Args, []).
+
+-spec open(pid()) -> {ok, #doc{}}.
+open(Pid) ->
+    gen_server:call(Pid, open).
+
+-spec open(pid(), term()) -> {ok, #doc{}}.
+open(Pid, To) ->
+    gen_server:call(Pid, {open, To}).
+
+-spec refresh(pid()) -> ok.
+refresh(Pid) ->
+    gen_server:cast(Pid, refresh).
+
+-spec recover(pid(), doc_key()) -> {ok, #doc{}} | {error, term()}.
+recover(Pid, Key) ->
+    gen_server:cast(Pid, {recover, recover(Key)}).
+
+-spec recover_info(pid(), doc_key()) -> {ok, #doc_info{}} | {error, term()}.
+recover_info(Pid, Key) ->
+    gen_server:cast(Pid, {recover_info, recover_info(Key)}).
+
+
+init(Key) ->
+    process_flag(trap_exit, true),
+    {ok, #state{key = Key}, 0}.
+
+handle_call(open, From, #state{queue = Q, tref = undefined} = State) ->
+    {noreply, State#state{queue = [From|Q]}};
+handle_call(open, From, #state{queue = Q, tref = TRef} = State) ->
+    {ok, cancel} = timer:cancel(TRef),
+    {noreply, State#state{queue=[From|Q], tref=undefined, handler=recover}, 0};
+handle_call({open, To}, _From, #state{queue = Q} = State) ->
+    {noreply, State#state{queue = [To|Q]}}.
+
+handle_cast(refresh, #state{tref = undefined} = State) ->
+    {noreply, State};
+handle_cast(refresh, #state{key = {DbName, DocId}, rev = Rev} = State) ->
+    {ok, cancel} = timer:cancel(State#state.tref),
+    case ets_lru:member(?CACHE, {DbName, DocId, Rev}) of
+    true ->
+        {noreply, State#state{tref = undefined, handler = recover_info}, 0};
+    false ->
+        {stop, normal, State#state{tref = undefined}}
+    end;
+handle_cast({recover_info, {ok, #doc_info{revs = RecRevs}}}, State) ->
+    Revs = [R || #rev_info{rev=R, deleted=D} <- RecRevs, D /= true],
+    [NewRev|_] = lists:sort(fun({A,_}, {B,_}) -> A > B end, Revs),
+    case NewRev =:= State#state.rev of
+    true ->
+        {noreply, State};
+    false ->
+        {noreply, State#state{pid=undefined, handler=recover}, 0}
+    end;
+handle_cast({recover_info, Reply}, #state{key = Key} = State) ->
+    twig:log(notice, "can't get doc info for ~p : ~w", [Key, Reply]),
+    {noreply, State};
+handle_cast({recover, {ok, Doc}}, #state{key = Key, queue = Q} = State) ->
+    case Key of
+    {_, DocId} when not is_atom(DocId) ->
+        {RevDepth, [RevHash| _]} = Doc#doc.revs,
+        Rev = {RevDepth, RevHash},
+        ok = store_ddoc(Key, Doc, Rev),
+        [gen_server:reply(From, {ok, Doc}) || From <- Q],
+        {noreply, State#state{queue = [], rev = Rev}};
+    _ ->
+        ok = store_ddoc(Key, Doc),
+        [gen_server:reply(From, {ok, Doc}) || From <- Q],
+        {noreply, State#state{queue = []}}
+    end;
+handle_cast({recover, Reply}, #state{queue = Q} = State) ->
+    [gen_server:reply(From, Reply) || From <- Q],
+    {noreply, State#state{queue = []}}.
+
+handle_info(timeout, #state{key = Key, handler = Handler} = State) ->
+    Self = self(),
+    Pid = proc_lib:spawn_link(fun() ->
+        erlang:apply(?MODULE, Handler, [Self, Key])
+    end),
+    {noreply, State#state{pid = Pid}};
+handle_info({'EXIT', Pid, normal}, #state{pid=Pid, rev=undefined} = State) ->
+    {stop, normal, State#state{pid = undefined}};
+handle_info({'EXIT', Pid, normal}, #state{pid=Pid} = State) ->
+    {ok, TRef} = timer:send_after(?REFRESH, self(), {'$gen_cast', refresh}),
+    {noreply, State#state{pid = undefined, tref = TRef}, hibernate};
+handle_info({'EXIT', Pid, Err}, #state{pid=Pid} = State) ->
+    {stop, {error, Err}, State#state{pid = undefined}};
+handle_info({'EXIT', _, _Reason}, State) ->
+    {noreply, State};
+handle_info(Msg, State) ->
+    {stop, {unknown_msg, Msg}, State}.
+
+terminate(Reason, #state{pid = Pid}) ->
+    case is_pid(Pid) andalso erlang:is_process_alive(Pid) of
+    true -> exit(Pid, Reason);
+    false -> ok
+    end.
+
+code_change(_OldVsn, State, _Extra) ->
+	{ok, State}.
+
+%% priv
+
+recover({DbName, validation_funs}) ->
+    ddoc_cache_opener:recover_validation_funs(DbName);
+recover({DbName, Mod}) when is_atom(Mod) ->
+    Mod:recover(DbName);
+recover({DbName, DocId}) ->
+    ddoc_cache_opener:recover_doc(DbName, DocId);
+recover({DbName, DocId, Rev}) ->
+    ddoc_cache_opener:recover_doc(DbName, DocId, Rev).
+
+recover_info({DbName, DocId}) ->
+    ddoc_cache_opener:recover_doc_info(DbName, DocId).
+
+store_ddoc(Key, Doc) ->
+    ok = ets_lru:insert(?CACHE, Key, Doc).
+
+store_ddoc({DbName, DocId} = Key, Doc, Rev) ->
+    ok = ets_lru:insert(?CACHE, {DbName, DocId, Rev}, Doc),
+    ok = ddoc_cache_fetcher_sup:set_revision(Key, Rev).

--- a/src/ddoc_cache_fetcher.erl
+++ b/src/ddoc_cache_fetcher.erl
@@ -37,7 +37,7 @@ open(Key) ->
         ddoc_cache_opener:lookup(Key)
     end.
 
--spec open(doc_key(), term()) -> {ok, #doc{}}.
+-spec open(doc_key(), term()) -> {ok, #doc{}} | {error, term()}.
 open(Key, To) ->
     {ok, Pid} = start(Key),
     case erlang:is_process_alive(Pid) of
@@ -110,7 +110,7 @@ recover({DbName, DocId}) ->
 recover({DbName, DocId, Rev}) ->
     ddoc_cache_opener:recover_doc(DbName, DocId, Rev).
 
-maybe_start_synchronizer({DbName, DocId}, Doc) when not is_atom(DocId) ->
+maybe_start_synchronizer({DbName, DocId}, Doc) ->
     {RevDepth, [RevHash| _]} = Doc#doc.revs,
     Rev = {RevDepth, RevHash},
     ok = ddoc_cache_opener:store_doc({DbName, DocId, Rev}, Doc),

--- a/src/ddoc_cache_fetcher_sup.erl
+++ b/src/ddoc_cache_fetcher_sup.erl
@@ -24,14 +24,11 @@ start_link(Args) ->
 %% @doc - Starts a child with given Id and MFArgs
 -spec start_child(term()) -> {ok, pid()} | {ok, 'ignore'} | {error, term()}.
 start_child(ChildId) ->
-    try ets:lookup(?MODULE, ChildId) of
-        [] ->
-            gen_server:call(?MODULE, {start_child, ChildId}, ?TIMEOUT);
-        [#entry{key = ChildId, pid = Pid}] ->
-            {ok, Pid}
-    catch
-        error:badarg ->
-            {error, {?MODULE, not_running}}
+    case get_child(ChildId) of
+    not_found ->
+        gen_server:call(?MODULE, {start_child, ChildId}, ?TIMEOUT);
+    Else ->
+        Else
     end.
 
 %% @doc - Get a pid of a child with a given Id

--- a/src/ddoc_cache_fetcher_sup.erl
+++ b/src/ddoc_cache_fetcher_sup.erl
@@ -90,13 +90,8 @@ get_revision(Key) ->
 
 init(Module) ->
     process_flag(trap_exit, true),
-    case ets:info(?MODULE) of
-    undefined ->
-        Idx = ets:new(?MODULE, [named_table, public, {keypos, #entry.key}]),
-        {ok, #state{worker = Module, index = Idx}};
-    _ ->
-        {stop, ets_already_started}
-    end.
+    Idx = ets:new(?MODULE, [named_table, public, {keypos, #entry.key}]),
+    {ok, #state{worker = Module, index = Idx}}.
 
 handle_call({start_child, ChildId}, _From, State) ->
     #state{worker = Module, index = Idx} = State,

--- a/src/ddoc_cache_fetcher_sup.erl
+++ b/src/ddoc_cache_fetcher_sup.erl
@@ -1,0 +1,196 @@
+% Copyright 2014 Cloudant. All rights reserved.
+
+-module(ddoc_cache_fetcher_sup).
+
+-behaviour(gen_server).
+-include_lib("stdlib/include/ms_transform.hrl").
+
+-export([start_link/1, start_child/1, get_child/1, terminate_child/1,
+    which_children/0, count_children/0, get_revision/1, set_revision/2]).
+%% gen_server's callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+    terminate/2, code_change/3]).
+
+-define(TIMEOUT, 10000).
+-define(WAIT, 5000).
+
+-record(entry, {key, pid, rev}).
+-record(state, {worker, index}).
+
+-spec start_link(atom()) -> {ok, pid()} | {error, term()}.
+start_link(Args) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Args, []).
+
+%% @doc - Starts a child with given Id and MFArgs
+-spec start_child(term()) -> {ok, pid()} | {ok, 'ignore'} | {error, term()}.
+start_child(ChildId) ->
+    try ets:lookup(?MODULE, ChildId) of
+        [] ->
+            gen_server:call(?MODULE, {start_child, ChildId}, ?TIMEOUT);
+        [#entry{key = ChildId, pid = Pid}] ->
+            {ok, Pid}
+    catch
+        error:badarg ->
+            {error, {?MODULE, not_running}}
+    end.
+
+%% @doc - Get a pid of a child with a given Id
+-spec get_child(term()) -> {ok, pid()} | not_found | {error, term()}.
+get_child(ChildId) ->
+    try ets:lookup(?MODULE, ChildId) of
+        [] ->
+            not_found;
+        [#entry{key = ChildId, pid = Pid}] ->
+            {ok, Pid}
+    catch
+        error:badarg ->
+            {error, {?MODULE, not_running}}
+    end.
+
+%% @doc - Kills the child with a given id
+-spec terminate_child(term()) -> ok | {error, term()}.
+terminate_child(ChildId) ->
+    try ets:member(?MODULE, ChildId) of
+        false -> ok;
+        true -> gen_server:call(?MODULE, {terminate_child, ChildId}, ?TIMEOUT)
+    catch
+        error:badarg -> {error, {?MODULE, not_running}}
+    end.
+
+%% @doc - Returns a list of key, pid pairs for all active children
+-spec which_children() -> [{term(), pid()}].
+which_children() ->
+    %% Match = ets:fun2ms(fun(#entry{key = Key, pid = Pid}) -> {Key, Pid} end),
+    %% io:format(">> ~p <<", [Match]),
+    Match = [{{entry,'$1','$2','_'},[],[{{'$1','$2'}}]}],
+    try ets:select(?MODULE, Match) of
+        Result -> Result
+    catch
+        error:badarg -> {error, {?MODULE, not_running}}
+    end.
+
+%% @doc - Returns a number of active children
+-spec count_children() -> non_neg_integer().
+count_children() ->
+    case ets:info(?MODULE, size) of
+    undefined -> 0;
+    N -> N
+    end.
+
+set_revision(Key, Rev) ->
+    try ets:update_element(?MODULE, Key, {#entry.rev, Rev}) of
+        true -> ok;
+        false -> not_found
+    catch
+        error:badarg -> {error, {?MODULE, not_running}}
+    end.
+
+get_revision(Key) ->
+    try ets:lookup(?MODULE, Key) of
+        [#entry{key = Key, rev = Rev}] -> {ok, Rev};
+        [] -> not_found
+    catch
+        error:badarg -> {error, {?MODULE, not_running}}
+    end.
+
+
+init(Module) ->
+    process_flag(trap_exit, true),
+    case ets:info(?MODULE) of
+    undefined ->
+        Idx = ets:new(?MODULE, [named_table, public, {keypos, #entry.key}]),
+        {ok, #state{worker = Module, index = Idx}};
+    _ ->
+        {stop, ets_already_started}
+    end.
+
+handle_call({start_child, ChildId}, _From, State) ->
+    #state{worker = Module, index = Idx} = State,
+    case ets:lookup(Idx, ChildId) of
+    [] ->
+        ChildSpec = {ChildId, {Module, start_link, [ChildId]}},
+        Reply = create_child(Idx, ChildSpec),
+        {reply, Reply, State};
+    [#entry{key = ChildId, pid = Pid}] ->
+        {reply, {ok, Pid}, State}
+  end;
+handle_call({terminate_child, ChildId}, _From, State) ->
+    #state{index = Idx} = State,
+    case ets:lookup(Idx, ChildId) of
+    [Child] -> shutdown_child(Idx, Child, shutdown);
+    [] -> ok
+    end,
+    {reply, ok, State};
+handle_call(Call, _From, State) ->
+    {stop, {unknown_call, Call}, State}.
+
+handle_cast(Cast, State) ->
+    {stop, {unknown_cast, Cast}, State}.
+
+handle_info({'EXIT', Pid, _Reason}, #state{index = Idx} = State) ->
+    ets:match_delete(Idx, #entry{pid = Pid, _='_'}),
+    {noreply, State};
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+terminate(Reason, #state{index = Idx}) ->
+    [shutdown_child(Idx, Child, Reason) || Child <- ets:tab2list(Idx)],
+    ets:delete(Idx),
+    ok.
+
+code_change(_, State, _) ->
+    {ok, State}.
+
+create_child(Idx, {ChildId, {M,F,A}}) ->
+    case catch apply(M, F, A) of
+    {ok, Pid} when is_pid(Pid) ->
+        case erlang:is_process_alive(Pid) of
+        true ->
+            ets:insert(Idx, #entry{key = ChildId, pid = Pid}),
+            {ok, Pid};
+        false ->
+            {ok, Pid}
+        end;
+    ignore ->
+        {ok, ignore};
+    {error, Err} ->
+        {error, Err};
+    Err ->
+        {error, Err}
+    end.
+
+shutdown_child(Idx, #entry{key = ChildId, pid = Pid}, Reason) ->
+    ets:delete(Idx, ChildId),
+    case monitor_child(Pid) of
+    ok ->
+        exit(Pid, Reason),
+        receive
+        {'DOWN', _MRef, process, Pid, Reason} ->
+            ok;
+        {'DOWN', _MRef, process, Pid, OtherReason} ->
+            {error, OtherReason}
+        after ?WAIT ->
+            exit(Pid, kill),
+            receive
+            {'DOWN', _MRef, process, Pid, killed} ->
+                ok;
+            {'DOWN', _MRef, process, Pid, OtherReason} ->
+                {error, OtherReason}
+            end
+        end;
+    {error, Err} ->
+        {error, Err}
+    end.
+
+monitor_child(Pid) ->
+    erlang:monitor(process, Pid),
+    unlink(Pid),
+    receive
+    {'EXIT', Pid, Reason} ->
+        receive
+        {'DOWN', _, process, Pid, _} ->
+            {error, Reason}
+        end
+    after 0 ->
+        ok
+    end.

--- a/src/ddoc_cache_fetcher_sup.erl
+++ b/src/ddoc_cache_fetcher_sup.erl
@@ -3,7 +3,6 @@
 -module(ddoc_cache_fetcher_sup).
 
 -behaviour(gen_server).
--include_lib("stdlib/include/ms_transform.hrl").
 
 -export([start_link/1, start_child/1, get_child/1, terminate_child/1,
     which_children/0, count_children/0, get_revision/1, set_revision/2]).
@@ -57,8 +56,6 @@ terminate_child(ChildId) ->
 %% @doc - Returns a list of key, pid pairs for all active children
 -spec which_children() -> [{term(), pid()}].
 which_children() ->
-    %% Match = ets:fun2ms(fun(#entry{key = Key, pid = Pid}) -> {Key, Pid} end),
-    %% io:format(">> ~p <<", [Match]),
     Match = [{{entry,'$1','$2','_'},[],[{{'$1','$2'}}]}],
     try ets:select(?MODULE, Match) of
         Result -> Result

--- a/src/ddoc_cache_keeper.erl
+++ b/src/ddoc_cache_keeper.erl
@@ -1,0 +1,33 @@
+% Copyright 2015 Cloudant. All rights reserved.
+
+-module(ddoc_cache_keeper).
+
+-behaviour(gen_server).
+-vsn(1).
+
+-export([start_link/0, init/1, handle_call/3, handle_cast/2,
+    handle_info/2, terminate/2, code_change/3]).
+
+-include("ddoc_cache.hrl").
+
+start_link() ->
+	gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    ets:new(?CACHE, [set, named_table, public, {keypos, #entry.key}]),
+    {ok, ok, hibernate}.
+
+handle_call(_, _, State) ->
+    {reply, ok, State, hibernate}.
+
+handle_cast(_, State) ->
+    {noreply, State, hibernate}.
+
+handle_info(_, State) ->
+    {noreply, State, hibernate}.
+
+terminate(_Reason, _State) ->
+    ets:delete(?CACHE).
+
+code_change(_OldVsn, State, _Extra) ->
+	{ok, State}.

--- a/src/ddoc_cache_opener.erl
+++ b/src/ddoc_cache_opener.erl
@@ -2,7 +2,7 @@
 
 -module(ddoc_cache_opener).
 -behaviour(gen_server).
--vsn(1).
+-vsn(2).
 
 -include_lib("couch/include/couch_db.hrl").
 -include_lib("mem3/include/mem3.hrl").

--- a/src/ddoc_cache_opener.erl
+++ b/src/ddoc_cache_opener.erl
@@ -107,7 +107,7 @@ match_newest(Key) ->
     {not_found, missing | deleted} |
     {timeout, any()} |
     {error, any()} |
-    {error, any() | any()}.
+    {error, any(), any()}.
 recover_doc(DbName, DDocId) ->
     fabric:open_doc(DbName, DDocId, []).
 
@@ -117,7 +117,7 @@ recover_doc(DbName, DDocId) ->
     {not_found, missing | deleted} |
     {timeout, any()} |
     {error, any()} |
-    {error, any() | any()}.
+    {error, any(), any()}.
 recover_doc(DbName, DDocId, Rev) ->
     {ok, [Resp]} = fabric:open_revs(DbName, DDocId, [Rev], []),
     Resp.
@@ -128,7 +128,7 @@ recover_doc(DbName, DDocId, Rev) ->
     {not_found, missing} |
     {timeout, any()} |
     {error, any()} |
-    {error, any() | any()}.
+    {error, any(), any()}.
 recover_doc_info(DbName, DDocId) ->
     fabric:get_doc_info(DbName, DDocId, [{r, "1"}]).
 
@@ -206,12 +206,6 @@ handle_cast({do_evict, DbName, DDocIds}, St) ->
 
 handle_cast(Msg, St) ->
     {stop, {invalid_cast, Msg}, St}.
-
-handle_info({'EXIT', _Pid, {open_ok, _, _}}, St) ->
-    {noreply, St};
-
-handle_info({'EXIT', _Pid, {open_error, _, _, _}}, St) ->
-    {noreply, St};
 
 handle_info({'EXIT', Pid, Reason}, #st{evictor=Pid}=St) ->
     twig:log(err, "ddoc_cache_opener evictor died ~w", [Reason]),

--- a/src/ddoc_cache_opener.erl
+++ b/src/ddoc_cache_opener.erl
@@ -29,7 +29,8 @@
     open_custom/2,
     evict_docs/2,
     lookup/1,
-    match_newest/1,
+    member/1,
+    store_doc/2,
     recover_doc/2,
     recover_doc/3,
     recover_doc_info/2,
@@ -85,21 +86,13 @@ lookup(Key) ->
             recover
     end.
 
--spec match_newest(doc_key()) -> {ok, #doc{}} | missing | recover.
-match_newest(Key) ->
-    try ets_lru:match_object(?CACHE, Key, '_') of
-        [] ->
-            missing;
-        Docs ->
-            Sorted = lists:sort(
-                fun (#doc{deleted=DelL, revs=L}, #doc{deleted=DelR, revs=R}) ->
-                    {not DelL, L} > {not DelR, R}
-                end, Docs),
-            {ok, hd(Sorted)}
-    catch
-        error:badarg ->
-            recover
-    end.
+-spec member(doc_key()) -> boolean().
+member(Key) ->
+    ets_lru:member(?CACHE, Key).
+
+-spec store_doc(doc_key(), term()) -> ok.
+store_doc(Key, Doc) ->
+    ok = ets_lru:insert(?CACHE, Key, Doc).
 
 %% @doc Returns the latest version of design doc
 -spec recover_doc(db_name(), doc_id()) ->

--- a/src/ddoc_cache_opener.erl
+++ b/src/ddoc_cache_opener.erl
@@ -4,6 +4,7 @@
 -behaviour(gen_server).
 -vsn(2).
 
+-include("ddoc_cache.hrl").
 -include_lib("couch/include/couch_db.hrl").
 -include_lib("mem3/include/mem3.hrl").
 
@@ -25,6 +26,7 @@
     open_doc/2,
     open_doc/3,
     open_validation_funs/1,
+    open_custom/2,
     evict_docs/2,
     lookup/1,
     match_newest/1,
@@ -39,42 +41,39 @@
 
 -define(CACHE, ddoc_cache_lru).
 
--type dbname() :: iodata().
--type docid() :: iodata() | atom().
--type doc_hash() :: <<_:128>>.
--type revision() :: {pos_integer(), doc_hash()}.
-
 -record(st, {
-    db_ddocs,
+    limiter,
     evictor
 }).
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
--spec open_doc(dbname(), docid()) ->
+-spec open_doc(db_name(), doc_id()) ->
     {ok, #doc{}} | {error, term()}.
 open_doc(DbName, DocId) ->
-    open_doc({DbName, DocId}).
+    ddoc_cache_fetcher:open({DbName, DocId}).
 
--spec open_doc(dbname(), docid(), revision()) ->
+-spec open_doc(db_name(), doc_id(), revision()) ->
     {ok, #doc{}} | {error, term()}.
 open_doc(DbName, DocId, Rev) ->
-    open_doc({DbName, DocId, Rev}).
+    ddoc_cache_fetcher:open({DbName, DocId, Rev}).
 
--spec open_validation_funs(dbname()) ->
+-spec open_validation_funs(db_name()) ->
     {ok, [fun()]} | {error, term()}.
 open_validation_funs(DbName) ->
-    open_doc({DbName, validation_funs}).
+    ddoc_cache_fetcher:open({DbName, custom, validation_funs}).
 
-open_doc(Key) ->
-    {ok, Pid} = ddoc_cache_fetcher_sup:start_child(Key),
-    ddoc_cache_fetcher:open(Pid).
+-spec open_custom(db_name(), atom()) ->
+    {ok, [term()]} | {error, term()}.
+open_custom(DbName, Mod) ->
+    ddoc_cache_fetcher:open({DbName, custom, Mod}).
 
--spec evict_docs(dbname(), [docid()]) -> ok.
+-spec evict_docs(db_name(), [doc_id()]) -> ok.
 evict_docs(DbName, DocIds) ->
     gen_server:cast(?MODULE, {evict, DbName, DocIds}).
 
+-spec lookup(doc_key()) -> {ok, #doc{}} | missing | recover.
 lookup(Key) ->
     try ets_lru:lookup_d(?CACHE, Key) of
         {ok, _} = Resp ->
@@ -86,6 +85,7 @@ lookup(Key) ->
             recover
     end.
 
+-spec match_newest(doc_key()) -> {ok, #doc{}} | missing | recover.
 match_newest(Key) ->
     try ets_lru:match_object(?CACHE, Key, '_') of
         [] ->
@@ -102,7 +102,7 @@ match_newest(Key) ->
     end.
 
 %% @doc Returns the latest version of design doc
--spec recover_doc(dbname(), docid()) ->
+-spec recover_doc(db_name(), doc_id()) ->
     {ok, #doc{}} |
     {not_found, missing | deleted} |
     {timeout, any()} |
@@ -112,7 +112,7 @@ recover_doc(DbName, DDocId) ->
     fabric:open_doc(DbName, DDocId, []).
 
 %% @doc Returns the given revision of design doc
--spec recover_doc(dbname(), docid(), revision()) ->
+-spec recover_doc(db_name(), doc_id(), revision()) ->
     {ok, #doc{}} |
     {not_found, missing | deleted} |
     {timeout, any()} |
@@ -123,7 +123,7 @@ recover_doc(DbName, DDocId, Rev) ->
     Resp.
 
 %% @doc Retrieves an information on a document with a given id
--spec recover_doc_info(dbname(), docid()) ->
+-spec recover_doc_info(db_name(), doc_id()) ->
     {ok, #doc_info{}} |
     {not_found, missing} |
     {timeout, any()} |
@@ -134,7 +134,7 @@ recover_doc_info(DbName, DDocId) ->
 
 %% @doc Returns a list of all the validation funs of the design docs
 %% in a given database
--spec recover_validation_funs(dbname()) -> {ok, [fun()]}.
+-spec recover_validation_funs(db_name()) -> {ok, [fun()]}.
 recover_validation_funs(DbName) ->
     {ok, DDocs} = fabric:design_docs(mem3:dbname(DbName)),
     Funs = lists:flatmap(fun(DDoc) ->
@@ -156,6 +156,7 @@ handle_db_event(_DbName, _Event, St) ->
 
 init(_) ->
     process_flag(trap_exit, true),
+    ets:new(?CACHE, [set, named_table, public, {keypos, #entry.key}]),
     {ok, Evictor} = couch_event:link_listener(
         ?MODULE, handle_db_event, nil, [all_dbs]
     ),
@@ -169,8 +170,7 @@ terminate(_Reason, St) ->
     ok.
 
 handle_call({open, OpenerKey}, From, St) ->
-    {ok, Pid} = ddoc_cache_fetcher_sup:start_child(OpenerKey),
-    ddoc_cache_fetcher:open(Pid, From),
+    ddoc_cache_fetcher:open(OpenerKey, From),
     {noreply, St};
 
 handle_call(Msg, _From, St) ->
@@ -192,15 +192,11 @@ handle_cast({do_evict, DbName}, St) ->
 handle_cast({do_evict, DbName, DDocIds}, St) ->
     CustomKeys = lists:flatten(ets_lru:match(?CACHE, {DbName, '$1'}, '_')),
     lists:foreach(fun(Mod) ->
+        ddoc_cache_synchronizer:stop({DbName, Mod}),
         ets_lru:remove(?CACHE, {DbName, Mod})
     end, CustomKeys),
     lists:foreach(fun(DDocId) ->
-        case ddoc_cache_fetcher_sup:get_child({DbName, DDocId}) of
-        {ok, Pid} ->
-            ddoc_cache_fetcher:refresh(Pid);
-        _ ->
-            ok
-        end
+        ddoc_cache_fetcher:start({DbName, DDocId})
     end, DDocIds),
     {noreply, St};
 
@@ -217,5 +213,56 @@ handle_info({'EXIT', Pid, Reason}, #st{evictor=Pid}=St) ->
 handle_info(Msg, St) ->
     {stop, {invalid_info, Msg}, St}.
 
+code_change(1, #st{evictor=Evictor}, _Extra) ->
+    {ok, #st{evictor = Evictor, limiter = get_limiter()}};
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+
+trim_cache(Limiter) ->
+    Pattern = #entry{key={'$2', '$3', {'$4', '$5'}}, ts='$1', _='_'},
+    MapFold = fun([Ts,DbName,DDocId,RevNum,RevHash], Dict) ->
+        Key = {DbName, DDocId, {RevNum, RevHash}},
+        case dict:find({DbName, DDocId}, Dict) of
+        {ok, {N,_} = MaxRev} when N > RevNum ->
+            MaxKey = {DbName, DDocId, MaxRev},
+            {{Ts, Key, MaxKey}, Dict};
+        _ ->
+            MaxRev = {RevNum, RevHash},
+            {{Ts, Key, Key}, dict:store({DbName, DDocId}, MaxRev, Dict)}
+        end
+    end,
+    {RevKeys, _} = lists:mapfoldl(MapFold, dict:new(),
+        ets:match(?CACHE, Pattern)),
+    trim_cache(lists:sort(RevKeys), true, Limiter).
+
+trim_cache(_, false, _) ->
+    ok;
+trim_cache([{_, Key, Key}|T], true, Limiter) ->
+    {DbName, DDocId, _} = Key,
+    remove_doc(Key),
+    remove_doc({DbName, DDocId}),
+    remove_match_docs({DbName, custom, '_'}),
+    trim_cache(T, Limiter(), Limiter);
+trim_cache([{_, Key, _}|T], true, Limiter) ->
+    remove_doc(Key),
+    trim_cache(T, Limiter(), Limiter);
+trim_cache(_,_,_) ->
+    ok.
+
+timestamp() ->
+    {Mg,S,M} = os:timestamp(),
+    Mg * 1000000 * 1000000 + S * 1000000 + M.
+
+get_limiter() ->
+    MaxObj = config:get_integer("ddoc_cache", "max_objects", 0),
+    SizePredicate = fun() ->
+        MaxObj > 0 andalso ets:info(?CACHE, size) > MaxObj
+    end,
+    MaxMem = config:get_integer("ddoc_cache", "max_size", 104857600),
+    MemPredicate = fun() ->
+        MaxMem > 0 andalso ets:info(?CACHE, memory) > MaxMem
+    end,
+    fun() ->
+        SizePredicate() or MemPredicate()
+    end.

--- a/src/ddoc_cache_opener.erl
+++ b/src/ddoc_cache_opener.erl
@@ -30,28 +30,19 @@
     match_newest/1,
     recover_doc/2,
     recover_doc/3,
+    recover_doc_info/2,
     recover_validation_funs/1
 ]).
 -export([
     handle_db_event/3
 ]).
--export([
-    fetch_doc_data/1
-]).
 
 -define(CACHE, ddoc_cache_lru).
--define(OPENING, ddoc_cache_opening).
 
 -type dbname() :: iodata().
--type docid() :: iodata().
+-type docid() :: iodata() | atom().
 -type doc_hash() :: <<_:128>>.
 -type revision() :: {pos_integer(), doc_hash()}.
-
--record(opener, {
-    key,
-    pid,
-    clients
-}).
 
 -record(st, {
     db_ddocs,
@@ -61,20 +52,24 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
--spec open_doc(dbname(), docid()) -> {ok, #doc{}}.
+-spec open_doc(dbname(), docid()) ->
+    {ok, #doc{}} | {error, term()}.
 open_doc(DbName, DocId) ->
-    Resp = gen_server:call(?MODULE, {open, {DbName, DocId}}, infinity),
-    handle_open_response(Resp).
+    open_doc({DbName, DocId}).
 
--spec open_doc(dbname(), docid(), revision()) -> {ok, #doc{}}.
+-spec open_doc(dbname(), docid(), revision()) ->
+    {ok, #doc{}} | {error, term()}.
 open_doc(DbName, DocId, Rev) ->
-    Resp = gen_server:call(?MODULE, {open, {DbName, DocId, Rev}}, infinity),
-    handle_open_response(Resp).
+    open_doc({DbName, DocId, Rev}).
 
--spec open_validation_funs(dbname()) -> {ok, [fun()]}.
+-spec open_validation_funs(dbname()) ->
+    {ok, [fun()]} | {error, term()}.
 open_validation_funs(DbName) ->
-    Resp = gen_server:call(?MODULE, {open, {DbName, validation_funs}}, infinity),
-    handle_open_response(Resp).
+    open_doc({DbName, validation_funs}).
+
+open_doc(Key) ->
+    {ok, Pid} = ddoc_cache_fetcher_sup:start_child(Key),
+    ddoc_cache_fetcher:open(Pid).
 
 -spec evict_docs(dbname(), [docid()]) -> ok.
 evict_docs(DbName, DocIds) ->
@@ -106,13 +101,40 @@ match_newest(Key) ->
             recover
     end.
 
+%% @doc Returns the latest version of design doc
+-spec recover_doc(dbname(), docid()) ->
+    {ok, #doc{}} |
+    {not_found, missing | deleted} |
+    {timeout, any()} |
+    {error, any()} |
+    {error, any() | any()}.
 recover_doc(DbName, DDocId) ->
     fabric:open_doc(DbName, DDocId, []).
 
+%% @doc Returns the given revision of design doc
+-spec recover_doc(dbname(), docid(), revision()) ->
+    {ok, #doc{}} |
+    {not_found, missing | deleted} |
+    {timeout, any()} |
+    {error, any()} |
+    {error, any() | any()}.
 recover_doc(DbName, DDocId, Rev) ->
     {ok, [Resp]} = fabric:open_revs(DbName, DDocId, [Rev], []),
     Resp.
 
+%% @doc Retrieves an information on a document with a given id
+-spec recover_doc_info(dbname(), docid()) ->
+    {ok, #doc_info{}} |
+    {not_found, missing} |
+    {timeout, any()} |
+    {error, any()} |
+    {error, any() | any()}.
+recover_doc_info(DbName, DDocId) ->
+    fabric:get_doc_info(DbName, DDocId, [{r, "1"}]).
+
+%% @doc Returns a list of all the validation funs of the design docs
+%% in a given database
+-spec recover_validation_funs(dbname()) -> {ok, [fun()]}.
 recover_validation_funs(DbName) ->
     {ok, DDocs} = fabric:design_docs(mem3:dbname(DbName)),
     Funs = lists:flatmap(fun(DDoc) ->
@@ -134,13 +156,10 @@ handle_db_event(_DbName, _Event, St) ->
 
 init(_) ->
     process_flag(trap_exit, true),
-    _ = ets:new(?OPENING, [set, protected, named_table, {keypos, #opener.key}]),
     {ok, Evictor} = couch_event:link_listener(
-            ?MODULE, handle_db_event, nil, [all_dbs]
-        ),
-    {ok, #st{
-        evictor = Evictor
-    }}.
+        ?MODULE, handle_db_event, nil, [all_dbs]
+    ),
+    {ok, #st{evictor = Evictor}}.
 
 terminate(_Reason, St) ->
     case is_pid(St#st.evictor) of
@@ -150,15 +169,9 @@ terminate(_Reason, St) ->
     ok.
 
 handle_call({open, OpenerKey}, From, St) ->
-    case ets:lookup(?OPENING, OpenerKey) of
-        [#opener{clients=Clients}=O] ->
-            ets:insert(?OPENING, O#opener{clients=[From | Clients]}),
-            {noreply, St};
-        [] ->
-            Pid = spawn_link(?MODULE, fetch_doc_data, [OpenerKey]),
-            ets:insert(?OPENING, #opener{key=OpenerKey, pid=Pid, clients=[From]}),
-            {noreply, St}
-    end;
+    {ok, Pid} = ddoc_cache_fetcher_sup:start_child(OpenerKey),
+    ddoc_cache_fetcher:open(Pid, From),
+    {noreply, St};
 
 handle_call(Msg, _From, St) ->
     {stop, {invalid_call, Msg}, {invalid_call, Msg}, St}.
@@ -182,101 +195,33 @@ handle_cast({do_evict, DbName, DDocIds}, St) ->
         ets_lru:remove(?CACHE, {DbName, Mod})
     end, CustomKeys),
     lists:foreach(fun(DDocId) ->
-        Revs = ets_lru:match(?CACHE, {DbName, DDocId, '$1'}, '_'),
-        lists:foreach(fun([Rev]) ->
-            ets_lru:remove(?CACHE, {DbName, DDocId, Rev})
-        end, Revs)
+        case ddoc_cache_fetcher_sup:get_child({DbName, DDocId}) of
+        {ok, Pid} ->
+            ddoc_cache_fetcher:refresh(Pid);
+        _ ->
+            ok
+        end
     end, DDocIds),
     {noreply, St};
 
 handle_cast(Msg, St) ->
     {stop, {invalid_cast, Msg}, St}.
 
+handle_info({'EXIT', _Pid, {open_ok, _, _}}, St) ->
+    {noreply, St};
+
+handle_info({'EXIT', _Pid, {open_error, _, _, _}}, St) ->
+    {noreply, St};
+
 handle_info({'EXIT', Pid, Reason}, #st{evictor=Pid}=St) ->
     twig:log(err, "ddoc_cache_opener evictor died ~w", [Reason]),
-    {ok, Evictor} = couch_event:link_listener(?MODULE, handle_db_event, nil, [all_dbs]),
+    {ok, Evictor} = couch_event:link_listener(
+        ?MODULE, handle_db_event, nil, [all_dbs]
+    ),
     {noreply, St#st{evictor=Evictor}};
-
-handle_info({'EXIT', _Pid, {open_ok, OpenerKey, Resp}}, St) ->
-    respond(OpenerKey, {open_ok, Resp}),
-    {noreply, St};
-
-handle_info({'EXIT', _Pid, {open_error, OpenerKey, Type, Error}}, St) ->
-    respond(OpenerKey, {open_error, Type, Error}),
-    {noreply, St};
-
-handle_info({'EXIT', Pid, Reason}, St) ->
-    Pattern = #opener{pid=Pid, _='_'},
-    case ets:match_object(?OPENING, Pattern) of
-        [#opener{key=OpenerKey, clients=Clients}] ->
-            _ = [gen_server:reply(C, {error, Reason}) || C <- Clients],
-            ets:delete(?OPENING, OpenerKey),
-            {noreply, St};
-        [] ->
-            {stop, {unknown_pid_died, {Pid, Reason}}, St}
-    end;
 
 handle_info(Msg, St) ->
     {stop, {invalid_info, Msg}, St}.
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
-
--spec fetch_doc_data({dbname(), validation_funs}) -> no_return();
-                    ({dbname(), atom()}) -> no_return();
-                    ({dbname(), docid()}) -> no_return();
-                    ({dbname(), docid(), revision()}) -> no_return().
-fetch_doc_data({DbName, validation_funs}=OpenerKey) ->
-    {ok, Funs} = recover_validation_funs(DbName),
-    ok = ets_lru:insert(?CACHE, OpenerKey, Funs),
-    exit({open_ok, OpenerKey, {ok, Funs}});
-fetch_doc_data({DbName, Mod}=OpenerKey) when is_atom(Mod) ->
-    % This is not actually a docid but rather a custom cache key.
-    % Treat the argument as a code module and invoke its recover function.
-    try Mod:recover(DbName) of
-        {ok, Result} ->
-            ok = ets_lru:insert(?CACHE, OpenerKey, Result),
-            exit({open_ok, OpenerKey, {ok, Result}});
-        Else ->
-            exit({open_ok, OpenerKey, Else})
-    catch
-        Type:Reason ->
-            exit({open_error, OpenerKey, Type, Reason})
-    end;
-fetch_doc_data({DbName, DocId}=OpenerKey) ->
-    try recover_doc(DbName, DocId) of
-        {ok, Doc} ->
-            {RevDepth, [RevHash| _]} = Doc#doc.revs,
-            Rev = {RevDepth, RevHash},
-            ok = ets_lru:insert(?CACHE, {DbName, DocId, Rev}, Doc),
-            exit({open_ok, OpenerKey, {ok, Doc}});
-        Else ->
-            exit({open_ok, OpenerKey, Else})
-    catch
-        Type:Reason ->
-            exit({open_error, OpenerKey, Type, Reason})
-    end;
-fetch_doc_data({DbName, DocId, Rev}=OpenerKey) ->
-    try recover_doc(DbName, DocId, Rev) of
-        {ok, Doc} ->
-            ok = ets_lru:insert(?CACHE, {DbName, DocId, Rev}, Doc),
-            exit({open_ok, OpenerKey, {ok, Doc}});
-        Else ->
-            exit({open_ok, OpenerKey, Else})
-    catch
-        Type:Reason ->
-            exit({open_error, OpenerKey, Type, Reason})
-    end.
-
-handle_open_response(Resp) ->
-    case Resp of
-        {open_ok, Value} -> Value;
-        {open_error, throw, Error} -> throw(Error);
-        {open_error, error, Error} -> erlang:error(Error);
-        {open_error, exit, Error} -> exit(Error)
-    end.
-
-respond(OpenerKey, Resp) ->
-    [#opener{clients=Clients}] = ets:lookup(?OPENING, OpenerKey),
-    _ = [gen_server:reply(C, Resp) || C <- Clients],
-    ets:delete(?OPENING, OpenerKey).

--- a/src/ddoc_cache_sup.erl
+++ b/src/ddoc_cache_sup.erl
@@ -17,12 +17,12 @@ start_link() ->
 init([]) ->
     Children = [
         {
-            ddoc_cache_lru,
-            {ets_lru, start_link, [ddoc_cache_lru, lru_opts()]},
+            ddoc_cache_keeper,
+            {ddoc_cache_keeper, start_link, []},
             permanent,
             5000,
             worker,
-            [ets_lru]
+            [ddoc_cache_keeper]
         },
         {
             ddoc_cache_fetcher_sup,
@@ -42,24 +42,3 @@ init([]) ->
         }
     ],
     {ok, {{one_for_one, 5, 10}, Children}}.
-
-
-lru_opts() ->
-    lists:append([
-        lru_opts(max_objects),
-        lru_opts(max_size),
-        lru_opts(max_lifetime)
-    ]).
-
-lru_opts(max_objects) ->
-    lru_opts(max_objects, config:get("ddoc_cache", "max_objects", "-1"));
-lru_opts(max_size) ->
-    lru_opts(max_size, config:get("ddoc_cache", "max_size", "104857600"));
-lru_opts(max_lifetime) ->
-    lru_opts(max_lifetime, config:get("ddoc_cache", "max_lifetime", "-1")).
-
-lru_opts(Key, String) ->
-    case list_to_integer(String) of
-    Num when Num > 0 -> [{Key, Num}];
-    _ -> []
-    end.

--- a/src/ddoc_cache_sup.erl
+++ b/src/ddoc_cache_sup.erl
@@ -26,7 +26,7 @@ init([]) ->
         },
         {
             ddoc_cache_fetcher_sup,
-            {ddoc_cache_fetcher_sup, start_link, [ddoc_cache_fetcher]},
+            {ddoc_cache_fetcher_sup, start_link, []},
             permanent,
             5000,
             supervisor,

--- a/src/ddoc_cache_sup.erl
+++ b/src/ddoc_cache_sup.erl
@@ -37,21 +37,21 @@ init([]) ->
 
 
 lru_opts() ->
-    case application:get_env(ddoc_cache, max_objects) of
-        {ok, MxObjs} when is_integer(MxObjs), MxObjs > 0 ->
-            [{max_objects, MxObjs}];
-        _ ->
-            []
-    end ++
-    case application:get_env(ddoc_cache, max_size) of
-        {ok, MxSize} when is_integer(MxSize), MxSize > 0 ->
-            [{max_size, MxSize}];
-        _ ->
-            []
-    end ++
-    case application:get_env(ddoc_cache, max_lifetime) of
-        {ok, MxLT} when is_integer(MxLT), MxLT > 0 ->
-            [{max_lifetime, MxLT}];
-        _ ->
-            []
+    lists:append([
+        lru_opts(max_objects),
+        lru_opts(max_size),
+        lru_opts(max_lifetime)
+    ]).
+
+lru_opts(max_objects) ->
+    lru_opts(max_objects, config:get("ddoc_cache", "max_objects", "-1"));
+lru_opts(max_size) ->
+    lru_opts(max_size, config:get("ddoc_cache", "max_size", "104857600"));
+lru_opts(max_lifetime) ->
+    lru_opts(max_lifetime, config:get("ddoc_cache", "max_lifetime", "-1")).
+
+lru_opts(Key, String) ->
+    case list_to_integer(String) of
+    Num when Num > 0 -> [{Key, Num}];
+    _ -> []
     end.

--- a/src/ddoc_cache_sup.erl
+++ b/src/ddoc_cache_sup.erl
@@ -25,6 +25,14 @@ init([]) ->
             [ets_lru]
         },
         {
+            ddoc_cache_fetcher_sup,
+            {ddoc_cache_fetcher_sup, start_link, [ddoc_cache_fetcher]},
+            permanent,
+            5000,
+            supervisor,
+            [ddoc_cache_fetcher_sup]
+        },
+        {
             ddoc_cache_opener,
             {ddoc_cache_opener, start_link, []},
             permanent,

--- a/src/ddoc_cache_synchronizer.erl
+++ b/src/ddoc_cache_synchronizer.erl
@@ -1,0 +1,114 @@
+% Copyright 2014 Cloudant. All rights reserved.
+
+-module(ddoc_cache_synchronizer).
+
+-behaviour(gen_server).
+-vsn(1).
+
+-export([start_link/1, start/2, refresh/1, stop/1]).
+
+%% gen_server.
+-export([init/1, handle_call/3, handle_cast/2,
+    handle_info/2, terminate/2, code_change/3]).
+
+-include("ddoc_cache.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+-define(CACHE, ddoc_cache_lru).
+-define(REFRESH, 60000).
+-record(state, {key, rev, pid, tref}).
+
+
+-spec start_link(doc_key()) -> {ok, pid()} | {error, term()}.
+start_link(Args) ->
+	gen_server:start_link(?MODULE, Args, []).
+
+-spec start(doc_key(), revision()) -> {ok, pid()}
+    | {ok, 'ignore'}  | {error, term()}.
+start(Key, Rev) ->
+    ChildSpec = {{synchronizer, Key}, ?MODULE, [{Key, Rev}]},
+    ddoc_cache_fetcher_sup:start_child(ChildSpec).
+
+-spec refresh(doc_key()) -> ok.
+refresh(Key) ->
+    case ddoc_cache_fetcher_sup:get_child({synchronizer, Key}) of
+    {ok, Pid} ->
+        gen_server:cast(Pid, refresh);
+    not_found ->
+        ok
+    end.
+
+-spec stop(doc_key()) -> ok | {error, term()}.
+stop(Key) ->
+    ddoc_cache_fetcher_sup:terminate_child({synchronizer, Key}).
+
+
+init({Key, Rev}) ->
+    process_flag(trap_exit, true),
+    {ok, TRef} = set_timer(?REFRESH),
+    {ok, #state{key = Key, rev = Rev, tref = TRef}, hibernate}.
+
+handle_call(Msg, _, State) ->
+    {stop, {invalid_call, Msg}, {invalid_call, Msg}, State}.
+
+handle_cast(refresh, #state{tref = undefined} = State) ->
+    {noreply, State};
+handle_cast(refresh, #state{key = {DbName, DocId}, rev = Rev} = State) ->
+    {ok, cancel} = timer:cancel(State#state.tref),
+    case ets_lru:member(?CACHE, {DbName, DocId, Rev}) of
+    true ->
+        Self = self(),
+        Pid = proc_lib:spawn_link(fun() ->
+            erlang:apply(fun recover/2, [Self, {DbName, DocId}])
+        end),
+        {noreply, State#state{tref = undefined, pid = Pid}};
+    false ->
+        {stop, normal, State#state{tref = undefined}}
+    end;
+handle_cast({recover, {ok, DocInfo}}, #state{rev = Rev} = State) ->
+    #doc_info{revs = RecRevs} = DocInfo,
+    Revs = [R || #rev_info{rev=R, deleted=D} <- RecRevs, D /= true],
+    case lists:sort(fun({A,_}, {B,_}) -> A > B end, Revs) of
+    [Rev|_] ->
+        {noreply, State};
+    _ ->
+        {DbName, DocId} = State#state.key,
+        ddoc_cache_opener:evict_docs(DbName, [DocId]),
+        {stop, normal, State#state{tref = undefined}}
+    end;
+handle_cast({recover, Reply}, #state{key = Key} = State) ->
+    twig:log(notice, "Can't get doc info for ~p : ~w", [Key, Reply]),
+    {noreply, State};
+handle_cast(Msg, State) ->
+    {stop, {invalid_cast, Msg}, State}.
+
+handle_info({'EXIT', Pid, normal}, #state{pid=Pid} = State) ->
+    {ok, TRef} = set_timer(?REFRESH),
+    {noreply, State#state{pid = undefined, tref = TRef}, hibernate};
+handle_info({'EXIT', Pid, Reason}, #state{pid=Pid} = State) ->
+    {stop, Reason, State#state{pid = undefined}};
+handle_info(Msg, State) ->
+    {stop, {invalid_info, Msg}, State}.
+
+terminate(Reason, #state{tref = undefined, pid = Pid}) ->
+    case is_pid(Pid) andalso erlang:is_process_alive(Pid) of
+    true -> exit(Pid, Reason);
+    false -> ok
+    end;
+terminate(Reason, #state{tref = TRef} = State) ->
+    {ok, cancel} = timer:cancel(TRef),
+    terminate(Reason, State#state{tref = undefined}).
+
+code_change(_OldVsn, State, _Extra) ->
+	{ok, State}.
+
+%% priv
+
+set_timer(Delay) ->
+    timer:send_after(Delay, self(), {'$gen_cast', refresh}).
+
+recover(Pid, Key) ->
+    gen_server:cast(Pid, {recover, recover(Key)}).
+
+recover({DbName, DocId}) ->
+    ddoc_cache_opener:recover_doc_info(DbName, DocId).

--- a/src/ddoc_cache_synchronizer.erl
+++ b/src/ddoc_cache_synchronizer.erl
@@ -14,7 +14,6 @@
 -include("ddoc_cache.hrl").
 -include_lib("couch/include/couch_db.hrl").
 
--define(CACHE, ddoc_cache_lru).
 -define(REFRESH, 60000).
 -record(state, {key, rev, pid, tref}).
 
@@ -55,7 +54,7 @@ handle_cast(refresh, #state{tref = undefined} = State) ->
     {noreply, State};
 handle_cast(refresh, #state{key = {DbName, DocId}, rev = Rev} = State) ->
     {ok, cancel} = timer:cancel(State#state.tref),
-    case ets_lru:member(?CACHE, {DbName, DocId, Rev}) of
+    case ddoc_cache_opener:member({DbName, DocId, Rev}) of
     true ->
         Self = self(),
         Pid = proc_lib:spawn_link(fun() ->

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,5 @@
+# Tests
+
+## How to run
+
+From top level, i.e. `dbcore` level : `rebar eunit apps=ddoc_cache verbose=1`

--- a/test/ddoc_cache_fetcher_sup_test.erl
+++ b/test/ddoc_cache_fetcher_sup_test.erl
@@ -1,0 +1,131 @@
+-module(ddoc_cache_fetcher_sup_test).
+
+-compile([export_all]).
+-export([init/1]).
+-behaviour(supervisor).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+default_test_() ->
+    {setup,
+        fun setup/0,
+        fun teardown/1,
+        fun test_run/1
+    }.
+
+setup() ->
+    Pid = spawn(fun() ->
+        process_flag(trap_exit, true),
+        {ok, SupPid} = supervisor:start_link({local, ?MODULE}, ?MODULE, []),
+        receive _ -> {ok, SupPid}
+        after infinity -> ok
+        end
+    end),
+    timer:sleep(50), %% give sup a moment to start
+    Pid.
+
+init([]) ->
+    Children = [{dummy_sup, {ddoc_cache_fetcher_sup, start_link, [dummy]},
+        transient, 50, supervisor, [ddoc_cache_fetcher_sup]}],
+    {ok, {{one_for_one, 1, 5}, Children}}.
+
+teardown(_Pid) ->
+    ok.
+
+test_run(Pid) ->
+    [
+        {"Supervisor alive",
+            ?_assert(is_process_alive(whereis(ddoc_cache_fetcher_sup)))},
+        {"Can call count with no children",
+            ?_assertEqual(0, ddoc_cache_fetcher_sup:count_children())},
+        {"Can start a child", ?_test(start_child())},
+        {"Can cound the child",
+            ?_assertEqual(1, ddoc_cache_fetcher_sup:count_children())},
+        {"Can find the child", ?_test(find_child())},
+        {"Handle finished children", ?_test(quit_child())},
+        {"Can start a child again", ?_test(start_child())},
+        {"Can terminate a child", ?_test(terminate_child())},
+        {"Handle exception in child", ?_test(explode_child())},
+        {"Can start number of children", ?_test(start_children())},
+        {"Can fetch list of children", ?_test(which_children())},
+        {"Can clean shutdown supervisor", ?_test(shutdown_sup(Pid))}
+    ].
+
+start_child() ->
+    {ok, Pid} = ddoc_cache_fetcher_sup:start_child(dummy),
+    RegPid = whereis(dummy),
+    ?assertEqual(Pid, RegPid),
+    ?assert(is_process_alive(Pid)).
+
+find_child() ->
+    RegPid = whereis(dummy),
+    {ok, Pid} = ddoc_cache_fetcher_sup:start_child(dummy),
+    ?assertEqual(Pid, RegPid),
+    ?assertEqual(1, ddoc_cache_fetcher_sup:count_children()).
+
+quit_child() ->
+    Pid = whereis(dummy),
+    Ref = erlang:monitor(process, Pid),
+    gen_server:call(dummy, {delay, 0}),
+    receive {'DOWN',Ref,process,_,Reason} -> ?assertEqual(Reason, normal)
+    end,
+    erlang:demonitor(Ref, [flush]),
+    erlang:yield(), %% give ets a chance
+    ?assertNot(is_process_alive(Pid)),
+    ?assertEqual(0, ddoc_cache_fetcher_sup:count_children()).
+
+terminate_child() ->
+    Pid = whereis(dummy),
+    Ref = erlang:monitor(process, Pid),
+    ok = ddoc_cache_fetcher_sup:terminate_child(dummy),
+    receive {'DOWN',Ref,process,_,Reason} -> ?assertEqual(Reason, shutdown)
+    end,
+    erlang:demonitor(Ref, [flush]),
+    erlang:yield(),
+    ?assertNot(is_process_alive(Pid)),
+    ?assertEqual(0, ddoc_cache_fetcher_sup:count_children()).
+
+explode_child() ->
+    start_child(),
+    Pid = whereis(dummy),
+    ?assertExit({{crowbar, _}, _}, gen_server:call(dummy, crash)),
+    timer:sleep(5),
+    ?assertNot(is_process_alive(Pid)),
+    ?assertEqual(0, ddoc_cache_fetcher_sup:count_children()).
+
+start_children() ->
+    lists:foreach(fun(I) ->
+        N = list_to_atom("dummy" ++ integer_to_list(I)),
+        {ok, Pid} = ddoc_cache_fetcher_sup:start_child(N),
+        ?assert(is_pid(Pid))
+    end, lists:seq(1,9)),
+    ?assertEqual(9, ddoc_cache_fetcher_sup:count_children()).
+
+which_children() ->
+    List = ddoc_cache_fetcher_sup:which_children(),
+    lists:foldl(fun({Id,Pid}, I) ->
+        N = list_to_atom("dummy" ++ integer_to_list(I)),
+        ?assertEqual(N, Id),
+        ?assert(is_pid(Pid)),
+        ?assert(is_process_alive(Pid)),
+        I + 1
+    end, 1, lists:sort(List)).
+
+shutdown_sup(Pid) ->
+    Parent = whereis(?MODULE),
+    SupPid = whereis(ddoc_cache_fetcher_sup),
+    List = ddoc_cache_fetcher_sup:which_children(),
+    ?assert(is_process_alive(Parent)),
+    ?assert(is_process_alive(SupPid)),
+    Ref = erlang:monitor(process, SupPid),
+    Pid ! stop,
+    receive {'DOWN',Ref,process,_,Reason} -> ?assertEqual(Reason, shutdown)
+    end,
+    erlang:demonitor(Ref, [flush]),
+    timer:sleep(5),
+    ?assertNot(is_process_alive(Parent)),
+    ?assertNot(is_process_alive(SupPid)),
+    lists:foreach(fun({_, P}) ->
+        ?assertNot(is_process_alive(P))
+    end, List).

--- a/test/ddoc_cache_fetcher_test.erl
+++ b/test/ddoc_cache_fetcher_test.erl
@@ -1,0 +1,171 @@
+-module(ddoc_cache_fetcher_test).
+
+-compile([export_all]).
+
+% -define(NODEBUG, true).
+-define (FABRIC_DELAY, 200).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+-record(cfg, {pid, doc, stash}).
+
+ok_test_() ->
+    {setup,
+        fun ok_setup/0,
+        fun ok_teardown/1,
+        fun ok_run/1
+    }.
+
+batch_test_() ->
+    {setup,
+        fun batch_setup/0,
+        fun batch_teardown/1,
+        fun batch_run/1
+    }.
+
+fail_test_() ->
+    {setup,
+        fun fail_setup/0,
+        fun fail_teardown/1,
+        fun fail_run/1
+    }.
+
+common_setup() ->
+    Doc = #doc{id = "doc", revs = {1, ["abc"]}},
+    Modules = [ddoc_cache_fetcher_sup,ets_lru, mem3, fabric],
+    ok = meck:new(Modules),
+    true = meck:validate(Modules),
+    meck:expect(ddoc_cache_fetcher_sup, set_revision, fun(_, _) -> ok end),
+    meck:expect(ets_lru, remove, fun(_, _) -> ok end),
+    meck:expect(ets_lru, insert, fun(_, _, _) -> ok end),
+    meck:expect(ets_lru, match, fun(_, _, _) -> [] end),
+    meck:expect(mem3, nodes, fun() -> [node()] end),
+    {ok, Doc}.
+
+ok_setup() ->
+    {ok, Doc} = common_setup(),
+    meck:expect(fabric, open_doc, fun(_, _, _) ->
+        timer:sleep(?FABRIC_DELAY),
+        {ok, Doc}
+    end),
+    meck:expect(fabric, open_revs, fun(_, _, _, _) ->
+        timer:sleep(?FABRIC_DELAY),
+        {ok, [{ok, Doc}]}
+    end),
+    % process_flag(trap_exit, true),
+    {ok, Pid} = ddoc_cache_fetcher:start_link({"db", "doc", "1-abc"}),
+    #cfg{pid = Pid, doc = Doc}.
+
+batch_setup() ->
+    {ok, Doc} = common_setup(),
+    meck:expect(fabric, open_doc, fun(_, _, _) ->
+        timer:sleep(?FABRIC_DELAY),
+        {ok, Doc}
+    end),
+    meck:expect(fabric, open_revs, fun(_, _, _, _) ->
+        timer:sleep(?FABRIC_DELAY),
+        {ok, [{ok, Doc}]}
+    end),
+    % process_flag(trap_exit, true),
+    {ok, Pid} = ddoc_cache_fetcher:start_link({"db", "doc", "1-abc"}),
+    Cfg = #cfg{pid = Pid, doc = Doc},
+    StashPid = spawn(?MODULE, stash, [Cfg, []]),
+    Cfg#cfg{stash = StashPid}.
+
+fail_setup() ->
+    {ok, Doc} = common_setup(),
+    #cfg{doc = Doc}.
+
+ok_teardown(_Cfg) ->
+    Modules = [ddoc_cache_fetcher_sup, ets_lru, mem3, fabric],
+    meck:unload(Modules).
+
+batch_teardown(#cfg{stash = Pid} = Cfg) ->
+    Pid ! done,
+    ok_teardown(Cfg).
+
+fail_teardown(Cfg) ->
+    ok_teardown(Cfg).
+
+ok_run(#cfg{pid = Pid, doc = Doc}) ->
+    {Time, Rsp} = timer:tc(ddoc_cache_fetcher, open, [Pid]),
+    [
+        {"A call waited for a response", ?_assert(Time >= ?FABRIC_DELAY)},
+        {"Got a proper response", ?_assertEqual(Rsp, {ok, Doc})},
+        {"Server's done and gone", ?_test(fun() ->
+            erlang:yield(),
+            ?assertNot(is_process_alive(Pid))
+        end)}
+    ].
+
+batch_run(#cfg{pid = Server, doc = Doc, stash = Pid}) ->
+    Pid ! {call, 10},
+    timer:sleep(2 * ?FABRIC_DELAY),
+    Pid ! {result, self()},
+    receive {ok, Acc} ->
+    [
+        {"Got all the expected responses", ?_assertEqual(length(Acc), 10)},
+        {"All the responses are proper",
+            ?_assert(lists:all(fun(D) -> D =:= Doc end, Acc))},
+        {"Server's done and gone", ?_test(fun() ->
+            erlang:yield(),
+            ?assertNot(is_process_alive(Server))
+        end)}
+    ]   
+    after 1000 ->
+        throw(timeout)
+    end.
+
+fail_run(_Cfg) ->
+    DoException = fun() ->
+        meck:expect(fabric, open_doc, fun(_, _, _) ->
+            timer:sleep(?FABRIC_DELAY),
+            meck:exception(throw, fabric)
+        end),
+        {ok, Pid} = gen_server:start(ddoc_cache_fetcher, {"db", "doc"}, []),
+        ?assert(is_process_alive(Pid)),
+        ?assertExit({{error,fabric},_}, gen_server:call(Pid, open)),
+        ?assertNot(is_process_alive(Pid))
+    end,
+    DoExit = fun() ->
+        meck:expect(fabric, open_doc, fun(_, _, _) ->
+            timer:sleep(?FABRIC_DELAY),
+            meck:exception(exit, fabric)
+        end),
+        {ok, Pid} = gen_server:start(ddoc_cache_fetcher, {"db", "doc"}, []),
+        ?assert(is_process_alive(Pid)),
+        ?assertExit({{error,fabric},_}, gen_server:call(Pid, open)),
+        ?assertNot(is_process_alive(Pid))
+    end,
+    DoError = fun() ->
+        meck:expect(fabric, open_doc, fun(_, _, _) ->
+            timer:sleep(?FABRIC_DELAY),
+            meck:exception(error, fabric)
+        end),
+        {ok, Pid} = gen_server:start(ddoc_cache_fetcher, {"db", "doc"}, []),
+        ?assert(is_process_alive(Pid)),
+        ?assertExit({{error,fabric},_}, gen_server:call(Pid, open)),
+        ?assertNot(is_process_alive(Pid))
+    end,
+    [
+        {"Exception from fabric call passed to fetcher",?_test(DoException())},
+        {"Exit from fabric call passed to fetcher", ?_test(DoExit())},
+        {"Error from fabric call passed to fetcher", ?_test(DoError())}
+    ].
+
+stash(#cfg{pid = Pid} = Cfg, Acc) ->
+    receive
+    {call, N} ->
+        Me = self(),
+        lists:foreach(fun(_) ->
+            spawn(fun() -> Me ! gen_server:call(Pid, open) end)
+        end, lists:seq(1,N)),
+        stash(Cfg, Acc);
+    {ok, Doc} ->
+        stash(Cfg, [Doc|Acc]);
+    {result, Caller} ->
+        Caller ! {ok, Acc},
+        stash(Cfg, Acc);
+    done ->
+        ok
+    end.

--- a/test/ddoc_cache_opener_test.erl
+++ b/test/ddoc_cache_opener_test.erl
@@ -3,37 +3,158 @@
 -compile([export_all]).
 
 -define(NODEBUG, true).
+-define(CACHE, ddoc_cache_lru).
 -define(FABRIC_DELAY, 100).
 -define(DELAY, 1000).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("couch/include/couch_db.hrl").
 
--record (cfg, {opener, stash}).
+-record (cfg, {sup, keeper, opener, stash}).
 -record (ctx, {state = blocked, queue = [], rt = 0, rc = 0}).
 
-main_test_() ->
+cache_crud_test_() ->
     {spawn, {setup,
-        fun setup/0,
-        fun teardown/1,
-        fun tests_builder/1
+        fun cache_setup/0,
+        fun cache_teardown/1,
+        fun cache_tests_builder/1
     }}.
 
-setup() ->
-    {ok, _SupPid} = ddoc_cache_fetcher_sup:start_link(),
-    {ok, OpenerPid} = ddoc_cache_opener:start_link(),
-    StashPid = spawn(?MODULE, stash, [#ctx{}]),
-    meck:new([ets_lru, mem3, fabric]),
-    %% blocking cache
-    meck:expect(ets_lru, remove, fun(_, _) -> ok end),
-    meck:expect(ets_lru, insert, fun(_, _, _) -> ok end),
-    meck:expect(ets_lru, match, fun(_, _, _) ->
-        Pid = self(),
-        StashPid ! {q, Pid},
-        receive {a, Pid} -> []
-        after infinity -> ok
+cache_setup() ->
+    meck:new([config]),
+    mock_config(0, 104857600),
+    {ok, KeeperPid, SupPid, OpenerPid} = start_opener(),
+    #cfg{sup = SupPid, keeper = KeeperPid, opener = OpenerPid}.
+
+cache_teardown(#cfg{sup = SupPid, keeper = KeeperPid, opener = OpenerPid}) ->
+    stop_opener(KeeperPid, SupPid, OpenerPid),
+    meck:unload([config]).
+
+cache_tests_builder(_Cfg) ->
+    [
+        {"cache exists", ?_test(assertCacheCreated())},
+        {"store some docs", ?_test(assertCanStore())},
+        {"lookup some docs", ?_test(assertCanLookup())},
+        {"check some docs", ?_test(assertCanCheckExistance())},
+        {"match some docs", ?_test(assertCanMatch())},
+        {"remove a doc", ?_test(assertCanRemove())},
+        {"remove matched docs", ?_test(assertCanMatchRemove())}
+    ].
+
+assertCacheCreated() ->
+    ets:info(?CACHE, size) =:= 0.
+
+assertCanStore() ->
+    Keys = [
+        {{a, a}, 1},
+        {{a, custom, validation}, 2},
+        {{a, a, {1, a}}, 3},
+        {{a, a, {2, b}}, 4},
+        {{a, a, {3, c}}, 5},
+        {{a, b}, 6},
+        {{a, b, {1, a}}, 7},
+        {{a, b, {2, b}}, 8},
+        {{a, b, {3, c}}, 9}
+    ],
+    Results = [ddoc_cache_opener:store_doc(K, V) || {K,V} <- Keys],
+    (length(Results) =:= length(Keys))
+        and lists:all(fun(R) -> R =:= ok end, Results).
+
+assertCanLookup() ->
+    A = ddoc_cache_opener:lookup({a, a}),
+    B = ddoc_cache_opener:lookup({a, custom, validation}),
+    C = ddoc_cache_opener:lookup({a, a, {3, c}}),
+    D = ddoc_cache_opener:lookup({a, b}),
+    E = ddoc_cache_opener:lookup({a, z}),
+    {A, B, C, D, E} =:= {{ok, 1}, {ok, 2}, {ok, 5}, {ok, 6}, missing}.
+
+assertCanCheckExistance() ->
+    A = ddoc_cache_opener:member({a, a}),
+    B = ddoc_cache_opener:member({a, z}),
+    C = ddoc_cache_opener:member({b, a}),
+    D = ddoc_cache_opener:member({a, a, {2, b}}),
+    {A, B, C, D} =:= {true, false, false, true}.
+
+assertCanMatch() ->
+    A = ddoc_cache_opener:match({a, '_'}),
+    B = ddoc_cache_opener:match({a, '_', '_'}),
+    C = ddoc_cache_opener:match({a, custom, '_'}),
+    (length(A) =:= 2) and (length(B) =:= 7) and (length(C) =:= 1).
+
+assertCanRemove() ->
+    A = ddoc_cache_opener:lookup({a, a, {1, a}}),
+    B = ddoc_cache_opener:remove_doc({a, a, {1, a}}),
+    C = ddoc_cache_opener:lookup({a, a, {1, a}}),
+    {A, B, C} =:= {5, ok, missing}.
+
+assertCanMatchRemove() ->
+    A = ddoc_cache_opener:match({a, custom, '_'}),
+    B = ddoc_cache_opener:remove_match_docs({a, custom, '_'}),
+    C = ddoc_cache_opener:match({a, custom, '_'}),
+    D = ddoc_cache_opener:match({a, '_', '_'}),
+    E = ddoc_cache_opener:remove_doc({a, '_', '_'}),
+    F = ddoc_cache_opener:match({a, '_', '_'}),
+    ({length(A), B, C} =:= {1, ok, []})
+        and ({length(D), E, F} =:= {5, ok, []}).
+
+
+lru_test_() ->
+    {spawn, {setup,
+        fun lru_setup/0,
+        fun lru_teardown/1,
+        fun lru_tests_builder/1
+    }}.
+
+lru_setup() ->
+    meck:new([config]),
+    mock_config(10, 2000),
+    {ok, KeeperPid, SupPid, OpenerPid} = start_opener(),
+    #cfg{sup = SupPid, keeper = KeeperPid, opener = OpenerPid}.
+
+lru_teardown(#cfg{sup = SupPid, keeper = KeeperPid, opener = OpenerPid}) ->
+    stop_opener(KeeperPid, SupPid, OpenerPid),
+    meck:unload([config]).
+
+lru_tests_builder(_Cfg) ->
+    [
+        {"cache exists", ?_test(assertCacheCreated())},
+        {"store 100 doc", ?_test(generate_ddocs(100))},
+        {"doc count limited", ?_test(assertDocsCount())},
+        {"cache size limited", ?_test(assertCacheSize())},
+        {"recently touched kept", ?_test(assertRecentKept())}
+    ].
+
+assertDocsCount() ->
+    Size = ets:info(?CACHE, size),
+    ?debugVal(Size),
+    Size =< 10.
+
+assertCacheSize() ->
+    Memory = ets:info(?CACHE, memory),
+    ?debugVal(Memory),
+    Memory =< 2000.
+
+assertRecentKept() ->
+    Result = lists:map(fun(I) ->
+        case ddoc_cache_opener:lookup({a, I, {1, a}}) of
+        {ok, _} -> true;
+        missing -> false
         end
-    end),
+    end, lists:seq(1, 5)),
+    lists:all(fun(True) -> True end, Result).
+
+
+fetch_test_() ->
+    {spawn, {setup,
+        fun fetch_setup/0,
+        fun fetch_teardown/1,
+        fun fetch_tests_builder/1
+    }}.
+
+fetch_setup() ->
+    {ok, KeeperPid, SupPid, OpenerPid} = start_opener(),
+    StashPid = spawn(?MODULE, stash, [#ctx{}]),
+    meck:new([mem3, fabric]),
     %% slow fabric
     meck:expect(fabric, open_doc, fun(_, Key, _) ->
         receive
@@ -41,14 +162,22 @@ setup() ->
             {ok, #doc{id = Key, revs = {1, ["abc"]}}}
         end
     end),
-    meck:expect(mem3, nodes, fun() -> [node()] end),
-    #cfg{opener = OpenerPid, stash = StashPid}.
+    %% blocking mem3
+    meck:expect(mem3, nodes, fun() ->
+        Pid = self(),
+        StashPid ! {q, Pid},
+        receive {a, Pid} -> [node()]
+        after infinity -> ok
+        end
+    end),
+    #cfg{sup=SupPid, keeper=KeeperPid, opener=OpenerPid, stash=StashPid}.
 
-teardown(#cfg{stash = StashPid}) ->
-    StashPid ! done,
-    meck:unload([ets_lru, mem3, fabric]).
+fetch_teardown(#cfg{sup=Sup, keeper=Keeper, opener=Opener, stash=Stash}) ->
+    stop_opener(Keeper, Sup, Opener),
+    Stash ! done,
+    meck:unload([mem3, fabric]).
 
-tests_builder(Cfg) ->
+fetch_tests_builder(Cfg) ->
     [
         {"ask 100 times for a slow ddoc", ?_test(mass_ask_for_ddoc(Cfg))},
         {"confirm opener's queue hasn't grow", ?_assert(assertQueueDry(Cfg))},
@@ -109,6 +238,43 @@ assertResponseDelayed(#cfg{stash = StashPid}) ->
 
 %% fixtures and helpers
 
+mock_config(Count, Size) ->
+    meck:expect(config, get_integer, fun
+        (_, "max_objects", _) -> Count;
+        (_, "max_size", _) -> Size
+    end).
+
+start_opener() ->
+    process_flag(trap_exit, true),
+    {ok, KeeperPid} = ddoc_cache_keeper:start_link(),
+    {ok, SupPid} = ddoc_cache_fetcher_sup:start_link(),
+    {ok, OpenerPid} = ddoc_cache_opener:start_link(),
+    {ok, KeeperPid, SupPid, OpenerPid}.
+
+stop_opener(KeeperPid, SupPid, OpenerPid) ->
+    lists:foreach(fun(Pid) ->
+        exit(Pid, shutdown),
+        receive
+            {'EXIT',Pid, shutdown} -> ok;
+        ?DELAY ->
+            exit({kill_timeout, Pid})
+        end
+    end, [OpenerPid, SupPid, KeeperPid]).
+
+generate_ddocs(N) ->
+    Keeper = fun() ->
+        lists:foreach(fun(I) ->
+            ddoc_cache_opener:lookup({a, I, {1, a}})
+        end, lists:seq(1, 5))
+    end,
+    lists:foreach(fun(I) ->
+        if I > 5 -> Keeper(); true -> ok end,
+        K = {a, I, {1, a}},
+        V = crypto:rand_bytes(1024),
+        ok = ddoc_cache_opener:store_doc(K, V)
+    end, lists:seq(1, N)),
+    true.
+
 mass_ask_for_ddoc(#cfg{stash = StashPid}) ->
     lists:foreach(fun(_) ->
         %% spawing because it is blocking
@@ -117,11 +283,12 @@ mass_ask_for_ddoc(#cfg{stash = StashPid}) ->
             {ok, _DDoc} = ddoc_cache_opener:open_doc(<<"one">>, <<"ddoc">>),
             StashPid ! {set_time, timer:now_diff(erlang:now(), T)}
         end)
-    end, lists:seq(1, 100)).
+    end, lists:seq(1, 100)),
+    true.
 
 flood_queue(#cfg{opener = OpenerPid}) ->
     lists:foreach(fun(_) ->
-        ok = gen_server:cast(OpenerPid, {do_evict, <<"two">>})
+        ok = gen_server:cast(OpenerPid, {evict, <<"two">>})
     end, lists:seq(1,100)).
 
 drain_queue(#cfg{stash = StashPid}) ->

--- a/test/ddoc_cache_opener_test.erl
+++ b/test/ddoc_cache_opener_test.erl
@@ -20,7 +20,7 @@ main_test_() ->
     }}.
 
 setup() ->
-    {ok, _SupPid} = ddoc_cache_fetcher_sup:start_link(ddoc_cache_fetcher),
+    {ok, _SupPid} = ddoc_cache_fetcher_sup:start_link(),
     {ok, OpenerPid} = ddoc_cache_opener:start_link(),
     StashPid = spawn(?MODULE, stash, [#ctx{}]),
     meck:new([ets_lru, mem3, fabric]),
@@ -81,7 +81,8 @@ assertFetcherQueueDry() ->
     ?assertEqual(Count, 1),
     %% get fetcher's pid
     Key = {<<"one">>, <<"ddoc">>},
-    {ok, Pid} = ddoc_cache_fetcher_sup:start_child(Key),
+    ChildSpec = {Key, ddoc_cache_fetcher, [Key]},
+    {ok, Pid} = ddoc_cache_fetcher_sup:start_child(ChildSpec),
     ?debugVal(Pid),
     ?assert(is_process_alive(Pid)),
     {_, Q} = process_info(Pid, message_queue_len),

--- a/test/ddoc_cache_opener_test.erl
+++ b/test/ddoc_cache_opener_test.erl
@@ -1,0 +1,150 @@
+-module(ddoc_cache_opener_test).
+
+-compile([export_all]).
+
+-define(NODEBUG, true).
+-define(FABRIC_DELAY, 100).
+-define(DELAY, 1000).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+-record (cfg, {opener, stash}).
+-record (ctx, {state = blocked, queue = [], rt = 0, rc = 0}).
+
+main_test_() ->
+    {spawn, {setup,
+        fun setup/0,
+        fun teardown/1,
+        fun tests_builder/1
+    }}.
+
+setup() ->
+    {ok, _SupPid} = ddoc_cache_fetcher_sup:start_link(ddoc_cache_fetcher),
+    {ok, OpenerPid} = ddoc_cache_opener:start_link(),
+    StashPid = spawn(?MODULE, stash, [#ctx{}]),
+    meck:new([ets_lru, mem3, fabric]),
+    %% blocking cache
+    meck:expect(ets_lru, remove, fun(_, _) -> ok end),
+    meck:expect(ets_lru, insert, fun(_, _, _) -> ok end),
+    meck:expect(ets_lru, match, fun(_, _, _) ->
+        Pid = self(),
+        StashPid ! {q, Pid},
+        receive {a, Pid} -> []
+        after infinity -> ok
+        end
+    end),
+    %% slow fabric
+    meck:expect(fabric, open_doc, fun(_, Key, _) ->
+        receive
+        after ?FABRIC_DELAY ->
+            {ok, #doc{id = Key, revs = {1, ["abc"]}}}
+        end
+    end),
+    meck:expect(mem3, nodes, fun() -> [node()] end),
+    #cfg{opener = OpenerPid, stash = StashPid}.
+
+teardown(#cfg{stash = StashPid}) ->
+    StashPid ! done,
+    meck:unload([ets_lru, mem3, fabric]).
+
+tests_builder(Cfg) ->
+    [
+        {"ask 100 times for a slow ddoc", ?_test(mass_ask_for_ddoc(Cfg))},
+        {"confirm opener's queue hasn't grow", ?_assert(assertQueueDry(Cfg))},
+        {"confirm fetcher's queue hasn't grow",
+            ?_assert(assertFetcherQueueDry())},
+        {"flood ddoc_cache_opener queue", ?_test(flood_queue(Cfg))},
+        {"confirm the queue flooded", ?_assert(assertQueueFlooded(Cfg))},
+        {"wait longer than fabric's delay", ?_test(timer:sleep(?DELAY))},
+        {"drain ddoc_cache_opener queue", ?_test(drain_queue(Cfg))},
+        {"confirm opener's queue drined", ?_assert(assertQueueDry(Cfg))},
+        {"confirm fetcher responded", ?_assert(assertResponsePassed(Cfg))},
+        {"confirm there was no delay", ?_assert(assertResponseDelayed(Cfg))}
+    ].
+
+%% assertions
+
+assertQueueFlooded(#cfg{opener = Pid}) ->
+    {_, Q} = erlang:process_info(Pid, message_queue_len),
+    ?debugVal(Q),
+    Q >= 10.
+
+assertQueueDry(#cfg{opener = Pid}) ->
+    {_, Q} = erlang:process_info(Pid, message_queue_len),
+    ?debugVal(Q),
+    Q < 10.
+
+assertFetcherQueueDry() ->
+    Count = ddoc_cache_fetcher_sup:count_children(),
+    ?debugVal(Count),
+    ?assertEqual(Count, 1),
+    %% get fetcher's pid
+    Key = {<<"one">>, <<"ddoc">>},
+    {ok, Pid} = ddoc_cache_fetcher_sup:start_child(Key),
+    ?debugVal(Pid),
+    ?assert(is_process_alive(Pid)),
+    {_, Q} = process_info(Pid, message_queue_len),
+    ?debugVal(Q),
+    Q =:= 0.
+
+assertResponsePassed(#cfg{stash = StashPid}) ->
+    StashPid ! {get_time, self()},
+    receive
+        {rtime, _, ClientsCount} ->
+            ?debugVal(ClientsCount),
+            ClientsCount =:= 100
+    after 1000 -> throw({stash, timeout})
+    end.
+
+assertResponseDelayed(#cfg{stash = StashPid}) ->
+    StashPid ! {get_time, self()},
+    receive
+        {rtime, Time, _} ->
+            ?debugVal(Time),
+            Time < ?DELAY andalso Time < 2 * ?FABRIC_DELAY
+    after 1000 -> throw({stash, timeout})
+    end.
+
+%% fixtures and helpers
+
+mass_ask_for_ddoc(#cfg{stash = StashPid}) ->
+    lists:foreach(fun(_) ->
+        %% spawing because it is blocking
+        spawn(fun() ->
+            T = erlang:now(),
+            {ok, _DDoc} = ddoc_cache_opener:open_doc(<<"one">>, <<"ddoc">>),
+            StashPid ! {set_time, timer:now_diff(erlang:now(), T)}
+        end)
+    end, lists:seq(1, 100)).
+
+flood_queue(#cfg{opener = OpenerPid}) ->
+    lists:foreach(fun(_) ->
+        ok = gen_server:cast(OpenerPid, {do_evict, <<"two">>})
+    end, lists:seq(1,100)).
+
+drain_queue(#cfg{stash = StashPid}) ->
+    StashPid ! unblock,
+    timer:sleep(5).
+
+stash(#ctx{queue = Q} = Ctx) ->
+    receive
+        {q, Pid} when Ctx#ctx.state =:= blocked ->
+            stash(Ctx#ctx{queue = [Pid|Q]});
+        {q, Pid} ->
+            Pid ! {a, Pid},
+            stash(Ctx);
+        {set_time, Time} ->
+            RC = Ctx#ctx.rc + 1,
+            RT = Ctx#ctx.rt + Time,
+            stash(Ctx#ctx{rc = RC, rt = RT});
+        {get_time, Pid} ->
+            Pid ! {rtime, Ctx#ctx.rt / (Ctx#ctx.rc * 1000), Ctx#ctx.rc},
+            stash(Ctx);
+        unblock ->
+            [Pid ! {a, Pid} || Pid <- Q],
+            stash(Ctx#ctx{state = unblocked});
+        done ->
+            ok
+    after infinity -> ok
+    end.

--- a/test/ddoc_cache_syncronizer_test.erl
+++ b/test/ddoc_cache_syncronizer_test.erl
@@ -1,0 +1,69 @@
+-module(ddoc_cache_syncronizer_test).
+
+-compile([export_all]).
+
+-define(NODEBUG, true).
+-define(DELAY, 1000).
+-define(CACHE, ddoc_cache_lru).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+-record(cfg, {sup, key, rev}).
+
+ok_test_() ->
+    {setup,
+        fun setup/0,
+        fun teardown/1,
+        fun build_tests/1
+    }.
+
+setup() ->
+    ets:new(?CACHE, [set, named_table, public]),
+    Modules = [ddoc_cache_opener],
+    ok = meck:new(Modules),
+    true = meck:validate(Modules),
+    meck:expect(ddoc_cache_opener, member, fun(_) ->
+        true
+    end),
+    meck:expect(ddoc_cache_opener, evict_docs, fun(_, _) ->
+        ok
+    end),
+    meck:expect(ddoc_cache_opener, recover_doc_info, fun(_, _) ->
+        {ok, #doc_info{revs = [#rev_info{rev={1, a}}]}}
+    end),
+    process_flag(trap_exit, true),
+    {ok, Pid} = ddoc_cache_fetcher_sup:start_link(),
+    #cfg{sup = Pid, key = {a, a}, rev = {1, a}}.
+
+teardown(#cfg{sup = Pid}) ->
+    Modules = [ddoc_cache_opener],
+    meck:unload(Modules),
+    exit(Pid, kill),
+    receive
+        {'EXIT',Pid,killed} -> ok;
+    ?DELAY ->
+        exit(sup_timeout)
+    end.
+
+build_tests(Cfg) ->
+    [
+        {"Start syncronizer", ?_test(assertSyncStart(Cfg))},
+        {"Refresh syncronizer", ?_test(assertSyncRefresh(Cfg))},
+        {"Stop syncronizer", ?_test(assertSyncStop(Cfg))}
+    ].
+
+assertSyncStart(#cfg{key = Key, rev = Rev}) ->
+    {ok, Pid} = ddoc_cache_synchronizer:start(Key, Rev),
+    {_,Info} = erlang:process_info(Pid, current_function),
+    ?debugVal(Info),
+    is_pid(Pid) and is_process_alive(Pid) and (Info =:= {erlang,hibernate,3}).
+
+assertSyncRefresh(#cfg{key = Key}) ->
+    Rsp = ddoc_cache_synchronizer:refresh(Key),
+    erlang:yield(),
+    Rsp =:= ok.
+
+assertSyncStop(#cfg{key = Key}) ->
+    Rsp = ddoc_cache_synchronizer:stop(Key),
+    erlang:yield(),
+    Rsp =:= ok.

--- a/test/dummy.erl
+++ b/test/dummy.erl
@@ -1,0 +1,35 @@
+-module(dummy).
+
+-behaviour(gen_server).
+
+-export([start_link/1]).
+-export([init/1, handle_call/3, handle_cast/2,
+    handle_info/2, terminate/2, code_change/3]).
+
+-record(ctx, {key, delay}).
+
+start_link(Key) ->
+    gen_server:start_link({local, Key}, ?MODULE, Key, []).
+
+init(Key) ->
+    {ok, #ctx{key = Key}}.
+
+handle_call(crash, _From, Ctx) ->
+    erlang:error(crowbar),
+    {reply, ok, Ctx};
+handle_call({delay, Delay}, _From, Ctx) ->
+    {reply, ok, Ctx#ctx{delay = Delay}, Delay}.
+
+handle_cast(_, Ctx) ->
+    {stop, {error, unknown_call}, Ctx}.
+
+handle_info(timeout, Ctx) ->
+    {stop, normal, Ctx};
+handle_info(_, Ctx) ->
+    {noreply, Ctx}.
+
+terminate(_Reason, _Ctx) ->
+    ok.
+
+code_change(_OldVsn, Ctx, _Extra) ->
+    {ok, Ctx}.


### PR DESCRIPTION
This PR changes how the cache handles opening and expiration of the ddocs.

Now each open_doc request spawns a separated `gen_server` process
under control of a custom supervisor. This process responds
to the requestors itself, so the response time do not depend
on how busy ddoc_opener's message queue is.

Opener process for none-revisioned ddocs made long-living, it does
a periodic check for a newest revision of its ddoc and in case
of an updated revision fetches the ddoc, keeping the cache warm.

BugsID: 28132
